### PR TITLE
[ZEET-1744] feat: legacy support: get self-managed node groups by tag:ZeetClusterId

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -66,6 +66,11 @@ locals {
     ]
   ])
 
-  asg_names = local.eks_node_group_asg_names + local.self_managed_node_group_asg_names
+  asg_names = toset(
+    concat(
+      local.eks_node_group_asg_names,
+      local.self_managed_node_group_asg_names
+    )
+  )
   topic_suffix = random_id.topic_id.hex
 }

--- a/main.tf
+++ b/main.tf
@@ -35,6 +35,16 @@ data "aws_eks_node_group" "node_group" {
   node_group_name = each.value
 }
 
+data "aws_autoscaling_groups" "ec2_node_groups" {
+  // when zeet_cluster_id is given, we can look up self-managed ec2 node groups
+  count = var.zeet_cluster_id != "" ? 1 : 0
+
+  filter {
+    name   = "tag:ZeetClusterId"
+    values = [var.zeet_cluster_id]
+  }
+}
+
 resource "random_id" "topic_id" {
   # 8 hex characters
   byte_length = 4
@@ -42,12 +52,20 @@ resource "random_id" "topic_id" {
 
 locals {
   # traverse eks node groups, collecting all asg names
-  asg_names = flatten([
+  eks_node_group_asg_names = flatten([
     for ng in data.aws_eks_node_group.node_group : [
       for resource in ng.resources : [
         for asg in resource.autoscaling_groups : asg.name
       ]
     ]
   ])
+
+  self_managed_node_group_asg_names = flatten([
+    for ng in data.aws_autoscaling_groups.ec2_node_groups : [
+      ng.names
+    ]
+  ])
+
+  asg_names = local.eks_node_group_asg_names + local.self_managed_node_group_asg_names
   topic_suffix = random_id.topic_id.hex
 }

--- a/variables.tf
+++ b/variables.tf
@@ -17,3 +17,9 @@ variable "sns_subscription_endpoint" {
 variable "sns_subscription_protocol" {
   default = "https"
 }
+
+variable "zeet_cluster_id" {
+  // optional
+  default = ""
+  description = "id for the zeet cluster record. optional: when non-empty, it will be used to look up self-managed ec2 node groups"
+}


### PR DESCRIPTION
- older zeet clusters use "self-managed" EC2 node groups (EC2 autoscaling groups) instead of EKS-managed ASGs
- these node groups are tagged by cluster, so we can list them
- this introduces a new variable `zeet_cluster_id`, when specified (non-empty string), will search EC2 asg's by tag
- Linear: https://linear.app/zeet/issue/ZEET-1744/alerting-or-legacy-cluster-monitoring